### PR TITLE
Floating license server documentation

### DIFF
--- a/Licenses/SoftingLicenseServer/README.md
+++ b/Licenses/SoftingLicenseServer/README.md
@@ -74,6 +74,7 @@ To start the container, run the following command. The image will be pulled and 
 
 ```
 docker run\
+    -it\
     --name licsrv\
     -p 6200:6200\
     --volume $(pwd)/license_files:/licsrv/licenses\


### PR DESCRIPTION
Adds a short introduction and table of contents, and a separate section about how to use the containerized version of the license server.